### PR TITLE
add ci for testdata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: End-to-end Test
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: null
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.14]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install build tools and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Install package (editable)
+        run: pip install git+https://github.com/DukeCosmology/roman_imsim.git
+
+      - name: Run GalSim
+        run: |
+          galsim hack.yaml
+
+      - name: Run unit tests
+        run: |
+          pytest tests/test_end_to_end.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: End-to-end Test
 
 on:
   push:
-    branches: [ main ]
+    paths:
+      - 'hack.yaml'
+      - 'reference/**'
   workflow_dispatch: null
 
 jobs:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.io import ascii
+
+REFERENCE_DIR = "reference"
+OUTPUT_DIR = "output"
+
+TEST_REPO = "."
+
+
+pytestmark = pytest.mark.skipif(
+    len(list(Path(TEST_REPO).iterdir())) == 0,
+    reason=f"Test data not available; {TEST_REPO} not initialized/updated",
+)
+
+ATOL = 0.1
+RTOL = 0
+
+
+def test_compare_truth():
+    reference_truth = (
+        Path(TEST_REPO) / REFERENCE_DIR / "RomanWAS_new" / "truth" / "Roman_WAS_index_J129_12909_4.txt"
+    )
+    output_truth = (
+        Path(TEST_REPO) / OUTPUT_DIR / "RomanWAS_new" / "truth" / "Roman_WAS_index_J129_12909_4.txt"
+    )
+
+    output_table = ascii.read(output_truth)
+    reference_table = ascii.read(reference_truth)
+
+    np.testing.assert_equal(reference_table.colnames, output_table.colnames)
+    np.testing.assert_equal(len(reference_table), len(output_table))
+
+    for output_col, reference_col in zip(
+        output_table.itercols(),
+        reference_table.itercols(),
+    ):
+        if isinstance(reference_col.dtype, np.dtypes.StrDType):
+            np.testing.assert_equal(output_col, reference_col)
+        else:
+            np.testing.assert_allclose(output_col, reference_col, rtol=RTOL, atol=ATOL)
+
+
+def test_compare_image():
+    reference_image = (
+        Path(TEST_REPO)
+        / REFERENCE_DIR
+        / "RomanWAS_new"
+        / "images"
+        / "truth"
+        / "Roman_WAS_truth_J129_12909_4.fits.gz"
+    )
+    output_image = (
+        Path(TEST_REPO)
+        / OUTPUT_DIR
+        / "RomanWAS_new"
+        / "images"
+        / "truth"
+        / "Roman_WAS_truth_J129_12909_4.fits.gz"
+    )
+
+    output_hdul = fits.open(output_image)
+    reference_hdul = fits.open(reference_image)
+
+    output_data = output_hdul[0].data
+    reference_data = reference_hdul[0].data
+
+    np.testing.assert_allclose(output_data, reference_data, rtol=RTOL, atol=ATOL)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -10,12 +10,6 @@ OUTPUT_DIR = "output"
 
 TEST_REPO = "."
 
-
-pytestmark = pytest.mark.skipif(
-    len(list(Path(TEST_REPO).iterdir())) == 0,
-    reason=f"Test data not available; {TEST_REPO} not initialized/updated",
-)
-
 ATOL = 0.1
 RTOL = 0
 


### PR DESCRIPTION
This runs the same end-to-end test as we have in `roman_imsim`. This should help make sure that the reference images and config file are updated at the same time. Right now, I expect this to break because we're still in an uncertain state between the two...

cf. https://github.com/DukeCosmology/roman_imsim/issues/93