### PR TITLE
Remove poisson flux

### DIFF
--- a/reference/RomanWAS_new/images/truth/Roman_WAS_truth_J129_12909_4.fits.gz
+++ b/reference/RomanWAS_new/images/truth/Roman_WAS_truth_J129_12909_4.fits.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7feaa184d0d9a4391e8b61ea78d2989530d4578c5f71ed65d7bcf7883a973d05
-size 18820298
+oid sha256:2b3d405be2af9b7bd7b3d699dbb91d1b94137f37eabfba23dab310bfbf477c5c
+size 18810105

--- a/reference/RomanWAS_new/truth/Roman_WAS_index_J129_12909_4.txt
+++ b/reference/RomanWAS_new/truth/Roman_WAS_index_J129_12909_4.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bbd7aab85c8b8afc6f92179fac49b776440c3678ca523ad19a2d26e3418f0059
-size 2923527
+oid sha256:b2fdc31fac1f1b4631e6d34f73957d9ec78693b180a6fe72920d294cd5315c5e
+size 2936991


### PR DESCRIPTION
This was branched from `action_make_image` a few commits ago, so wait for https://github.com/DukeCosmology/roman_imsim_testdata/pull/12 to be merged and then rebase accordingly. This updates the image for https://github.com/DukeCosmology/roman_imsim/pull/99